### PR TITLE
Fix attendance update bugs

### DIFF
--- a/controllers/studentController.js
+++ b/controllers/studentController.js
@@ -504,14 +504,14 @@ var studentController = {
         chosenFitzroy.kidsToAvoid = req.body.kidsToAvoid || []
         chosenFitzroy.attendance = typeof req.body.fitzroyBooks === 'string'
           ? req.body.fitzroyTutors === 'unknown'
-            ? { book: req.body.fitzroyBooks, date: req.body.saturdates, completed: req.body.fitzroyCompleted }
-            : { tutor: req.body.fitzroyTutors, book: req.body.fitzroyBooks, date: req.body.saturdates, completed: req.body.fitzroyCompleted }
+              ? { book: req.body.fitzroyBooks, date: req.body.saturdates, completed: req.body.fitzroyCompleted }
+              : { tutor: req.body.fitzroyTutors, book: req.body.fitzroyBooks, date: req.body.saturdates, completed: req.body.fitzroyCompleted }
           : req.body.fitzroyBooks
             ? req.body.fitzroyBooks.map(function (book) {
               var obj = {}
               req.body.fitzroyTutors[0] === 'unknown'
-              ? req.body.fitzroyTutors.shift()
-              : obj['tutor'] = req.body.fitzroyTutors.shift()
+                ? req.body.fitzroyTutors.shift()
+                : obj['tutor'] = req.body.fitzroyTutors.shift()
               obj['book'] = book
               obj['date'] = req.body.saturdates.shift()
               if (req.body.fitzroyCompleted) {

--- a/controllers/studentController.js
+++ b/controllers/studentController.js
@@ -474,6 +474,22 @@ var studentController = {
     },
 
     update: function (req, res) {
+
+      // when a Saturdate is unchecked
+      // the former values of book, tutor, and completed
+      // are replaced by empty strings
+      // remove these empty strings before processing attendance
+
+      if (typeof req.body.fitzroyBooks !== 'string') {
+        req.body.fitzroyBooks = req.body.fitzroyBooks.filter(function(book) { return book !== '' })
+      }
+      if (typeof req.body.fitzroyTutors !== 'string') {
+        req.body.fitzroyTutors = req.body.fitzroyTutors.filter(function(tutor) { return tutor !== '' })
+      }
+      if (typeof req.body.fitzroyCompleted !== 'string') {
+        req.body.fitzroyCompleted = req.body.fitzroyCompleted.filter(function(completed) { return completed !== '' })
+      }
+
       Fitzroy.findById(req.params.id, function (err, chosenFitzroy) {
         chosenFitzroy.name = req.body.name
         chosenFitzroy.gender = req.body.gender

--- a/controllers/studentController.js
+++ b/controllers/studentController.js
@@ -513,7 +513,9 @@ var studentController = {
                 ? req.body.fitzroyTutors.shift()
                 : obj['tutor'] = req.body.fitzroyTutors.shift()
               obj['book'] = book
-              obj['date'] = req.body.saturdates.shift()
+              typeof req.body.saturdates === 'string'
+                ? obj['date'] = req.body.saturdates
+                : obj['date'] = req.body.saturdates.shift()
               if (req.body.fitzroyCompleted) {
                 if (obj['book'] !== '0') {
                   typeof req.body.fitzroyCompleted === 'string'

--- a/views/students/fitzroy/edit.ejs
+++ b/views/students/fitzroy/edit.ejs
@@ -279,17 +279,8 @@
                       }
                       saturdatesCheckbox.onchange = function () {
                         if (this.checked) {
-                          if (fitzroyTutorSelect.hasChildNodes() && fitzroyTutorSelect.firstChild.value === "" && fitzroyTutorSelect.childNodes[1] === "") {
-                            fitzroyTutorSelect.remove(fitzroyTutorSelect.firstChild)
-                          }
                           fitzroyTutorDiv.removeAttribute('style')
-                          if (fitzroyBookSelect.hasChildNodes() && fitzroyBookSelect.firstChild.value === "" && fitzroyBookSelect.childNodes[1] === "") {
-                            fitzroyBookSelect.remove(fitzroyBookSelect.firstChild)
-                          }
                           fitzroyBookDiv.removeAttribute('style')
-                          if (fitzroyCompletedSelect.hasChildNodes() && fitzroyCompletedSelect.firstChild.value === "" && fitzroyCompletedSelect.childNodes[1] === "") {
-                            fitzroyCompletedSelect.remove(fitzroyCompletedSelect.firstChild)
-                          }
                           fitzroyCompletedDiv.removeAttribute('style')
                         } else {
                           if (fitzroyTutorSelect.options[fitzroyTutorSelect.selectedIndex].value !== "") {

--- a/views/students/fitzroy/edit.ejs
+++ b/views/students/fitzroy/edit.ejs
@@ -292,21 +292,30 @@
                           }
                           fitzroyCompletedDiv.removeAttribute('style')
                         } else {
-                          if (fitzroyTutorSelect.hasChildNodes()) {
+                          if (fitzroyTutorSelect.options[fitzroyTutorSelect.selectedIndex].value !== "") {
+                            fitzroyTutorSelect.options[fitzroyTutorSelect.selectedIndex].removeAttribute('selected')
+                          }
+                          if (fitzroyTutorSelect.hasChildNodes() && fitzroyTutorSelect.options[0].value !== "") {
                             var blank = new Option("Please select", "", true, true)
                             blank.setAttribute('disabled', true)
                             blank.setAttribute('hidden', true)
                             fitzroyTutorSelect.insertBefore(blank, fitzroyTutorSelect.firstChild)
                           }
                           fitzroyTutorDiv.setAttribute('style', 'display:none; visibility:hidden')
-                          if (fitzroyBookSelect.hasChildNodes()) {
+                          if (fitzroyBookSelect.options[fitzroyBookSelect.selectedIndex].value !== "") {
+                            fitzroyBookSelect.options[fitzroyBookSelect.selectedIndex].removeAttribute('selected')
+                          }
+                          if (fitzroyBookSelect.hasChildNodes() && fitzroyBookSelect.options[0].value !== "") {
                             var blank = new Option("Please select", "", true, true)
                             blank.setAttribute('disabled', true)
                             blank.setAttribute('hidden', true)
                             fitzroyBookSelect.insertBefore(blank, fitzroyBookSelect.firstChild)
                           }
                           fitzroyBookDiv.setAttribute('style', 'display:none; visibility:hidden')
-                          if (fitzroyCompletedSelect.hasChildNodes()) {
+                          if (fitzroyCompletedSelect.options[fitzroyCompletedSelect.selectedIndex].value !== "") {
+                            fitzroyCompletedSelect.options[fitzroyCompletedSelect.selectedIndex].removeAttribute('selected')
+                          }
+                          if (fitzroyCompletedSelect.hasChildNodes() && fitzroyCompletedSelect.options[0].value !== "") {
                             var blank = new Option("Please select", "", true, true)
                             blank.setAttribute('disabled', true)
                             blank.setAttribute('hidden', true)

--- a/views/students/fitzroy/edit.ejs
+++ b/views/students/fitzroy/edit.ejs
@@ -288,7 +288,6 @@
                           }
                           if (fitzroyTutorSelect.hasChildNodes() && fitzroyTutorSelect.options[0].value !== "") {
                             var blank = new Option("Please select", "", true, true)
-                            blank.setAttribute('disabled', true)
                             blank.setAttribute('hidden', true)
                             fitzroyTutorSelect.insertBefore(blank, fitzroyTutorSelect.firstChild)
                           }
@@ -298,7 +297,6 @@
                           }
                           if (fitzroyBookSelect.hasChildNodes() && fitzroyBookSelect.options[0].value !== "") {
                             var blank = new Option("Please select", "", true, true)
-                            blank.setAttribute('disabled', true)
                             blank.setAttribute('hidden', true)
                             fitzroyBookSelect.insertBefore(blank, fitzroyBookSelect.firstChild)
                           }
@@ -308,7 +306,6 @@
                           }
                           if (fitzroyCompletedSelect.hasChildNodes() && fitzroyCompletedSelect.options[0].value !== "") {
                             var blank = new Option("Please select", "", true, true)
-                            blank.setAttribute('disabled', true)
                             blank.setAttribute('hidden', true)
                             fitzroyCompletedSelect.insertBefore(blank, fitzroyCompletedSelect.firstChild)
                           }


### PR DESCRIPTION
Found bugs with updating attendance of a Fitzroy student:

1. "Please Select" option was being added to book, tutor, and completed for each Saturdate, each time the Saturdate's checkbox was selected, resulting in repeated additions if the checkbox is deselected multiple times. Criteria to add the option is now clarified.

2. When a Saturdate was deselected at the edit page, the corresponding values for book, tutor, and completed were not deselected. To fix this, the `selected` attribute for these values will now be removed when the Saturdate checkbox is unchecked, and the empty string value of the "Please Select" option added will not be disabled.

3. In the studentController, there was no check for the type of `req.body.saturdates`, which may be a string or an array, causing the app to crash when `.shift()` is called on a string. Type check has been added to fix this.